### PR TITLE
Fixes example placeholder for address

### DIFF
--- a/docs/guide/forms/README.md
+++ b/docs/guide/forms/README.md
@@ -256,7 +256,7 @@ an entire form from a JSON string.
     type: 'text',
     name: 'address',
     label: 'What is your street address?',
-    placeholder: 'Your name...',
+    placeholder: 'Your address...',
     help: 'Where would you like your product shipped?',
     validation: 'required'
   },


### PR DESCRIPTION
Changes the example placeholder for address from 'Your name...' to 'Your address...'