### PR TITLE
Fix component registration

### DIFF
--- a/docs/guide/custom-inputs/README.md
+++ b/docs/guide/custom-inputs/README.md
@@ -164,7 +164,7 @@ import VueFormulate from '@braid/vue-formulate'
 import MyFormulateAutocomplete from './MyFormulateAutocomplete'
 
 // register your component with Vue
-Vue.use('MyFormulateAutocomplete', MyFormulateAutocomplete)
+Vue.component('MyFormulateAutocomplete', MyFormulateAutocomplete)
 
 Vue.use(VueFormulate, {
   library: {


### PR DESCRIPTION
Use `Vue.component` instead of `Vue.use` for component registration.