### PR TITLE
Typo + sample code hidden input field

### DIFF
--- a/docs/guide/inputs/text/README.md
+++ b/docs/guide/inputs/text/README.md
@@ -122,6 +122,14 @@ While technically Vue Formulate does support hidden input fields, the use case
 is pretty minimal since you can easily inject your own "hidden" values into
 submitted data with a [form submission](/guide/forms).
 
+```vue
+<FormulateInput
+  type="hidden"
+  name="sample"
+  value="secret-code"
+/>
+```
+
 ## Month
 
 

--- a/docs/guide/inputs/text/README.md
+++ b/docs/guide/inputs/text/README.md
@@ -120,7 +120,7 @@ number keypad for mobile users.
 
 While technically Vue Formulate does support hidden input fields, the use case
 is pretty minimal since you can easily inject your own "hidden" values into
-submitted data with your a [form submission](/guide/forms).
+submitted data with a [form submission](/guide/forms).
 
 ## Month
 


### PR DESCRIPTION
I removed the word 'your' in the paragraph about hidden input fields and added the sample code for adding one.