### PR TITLE
Nuxt installation instructions

### DIFF
--- a/docs/guide/installation/README.md
+++ b/docs/guide/installation/README.md
@@ -53,6 +53,28 @@ Vue.use(VueFormulate.default)
 ```
 :::
 
+### Nuxt
+It's easy to use Vue Formulate on Nuxt too. [A working example is available.](https://codesandbox.io/s/vue-formulate-test-8segh?file=/components/Attending.vue)
+
+#### plugins/vue-formulate.js
+
+```js
+import Vue from 'vue'
+import VueFormulate from '@braid/vue-formulate'
+
+Vue.use(VueFormulate)
+```
+
+#### nuxt.config.js
+
+```js
+export default {
+  plugins: [
+     '~/plugins/vue-formulate',
+  ]
+  (...)
+```
+
 ## Configuration options
 
 If you need custom configuration options, you can pass a second argument with


### PR DESCRIPTION
Added some simple _(but helpful)_ installation instructions for Nuxt users.

Linking to codesandbox example from @SuddenDev (from https://github.com/wearebraid/vue-formulate/issues/75)