### PR TITLE
Added an explanation on how to use slots in groups

### DIFF
--- a/docs/guide/inputs/types/group/README.md
+++ b/docs/guide/inputs/types/group/README.md
@@ -380,17 +380,18 @@ Example:
                 name="attendees"
                 :repeatable="true"
                 add-label="+ Add Attendee"
-            >   <template v-slot:default="groupProps">
+            >
+            <template v-slot:default="groupProps">
               
-              <p>This is Group # {{index}} </p>
+              <p>This is Group # {{groupProps.index}} </p>
                 <FormulateInput
                                 name="price"
                                 disabled
                                 :value="getPrice(groupProps.index)"
                                 label="Price""
                             />
-                </template>
-            </FormulateInput>
+            </template>
+ </FormulateInput>
             
 ```
 

--- a/docs/guide/inputs/types/group/README.md
+++ b/docs/guide/inputs/types/group/README.md
@@ -367,6 +367,35 @@ export default {
 :::
 <demo-group-validation />
 
+## Index of current group
+
+To manipulate a distinct group field, it is helpful to get the index of the current group item. Luckily, slots can help. The `default` slot for instance offers the `index` as a context variable:
+
+Example:
+
+
+```
+ <FormulateInput
+                type="group"
+                name="attendees"
+                :repeatable="true"
+                add-label="+ Add Attendee"
+            >   <template v-slot:default="groupProps">
+              
+              <p>This is Group # {{index}} </p>
+                <FormulateInput
+                                name="price"
+                                disabled
+                                :value="getPrice(index)"
+                                label="Price""
+                            />
+                </template>
+            </FormulateInput>
+            
+```
+
+
+
 ## Props
 
 The group field has a few unique props:

--- a/docs/guide/inputs/types/group/README.md
+++ b/docs/guide/inputs/types/group/README.md
@@ -369,12 +369,12 @@ export default {
 
 ## Index of current group
 
-To manipulate a distinct group field, it is helpful to get the index of the current group item. Luckily, slots can help. The `default` slot for instance offers the `index` as a context variable:
+To manipulate a distinct group field, it is helpful to get the index of the current group item. Luckily, slots can help. The `default` slot for instance offers the `index` as a context variable of `groupProps`:
 
 Example:
 
 
-```
+```vue
  <FormulateInput
                 type="group"
                 name="attendees"
@@ -386,7 +386,7 @@ Example:
                 <FormulateInput
                                 name="price"
                                 disabled
-                                :value="getPrice(index)"
+                                :value="getPrice(groupProps.index)"
                                 label="Price""
                             />
                 </template>


### PR DESCRIPTION
The documentation was a bit vague on how to get the context of the current group. So I added a simple example.