### PR TITLE
applies styling to fix overflow scrolling on live code editors

### DIFF
--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -42,20 +42,45 @@
   font-size: 0.85em;;
   line-height: 1.4;
 
-// .prism-editor-wrapper
-//   .prism-editor__textarea, .prism-editor__editor
-//     white-space: pre !important
-//     width: 100%
-//   .prism-editor__textarea
-//     position: absolute !important;
-//     top: 0 !important
-//     left: 0 !important
-//     width: 100% !important
-//     z-index: 1
-//     overflow: auto !important
-//   .prism-editor__editor
-//     overflow: hidden
 
+.preview-code
+  position relative
+
+.editor.block
+  display flex
+  overflow auto
+
+  &::before
+    display none
+
+.prism-editor-wrapper
+  display flex
+  overflow: visible !important
+  width: auto !important
+  .prism-editor__container
+    overflow: visible !important
+    white-space: nowrap
+    display flex
+    width auto !important
+    height 100% !important
+  .prism-editor__textarea, .prism-editor__editor
+    white-space: pre !important
+    overflow: hidden !important
+    white-space pre !important
+    display: block !important
+  .prism-editor__textarea
+    position: absolute !important
+    top: 0 !important
+    left: 0 !important
+    right: 0 !important
+    width: 100% !important
+    z-index: 1
+    height: 100% !important
+  .prism-editor__editor
+    overflow: auto
+    display: block
+    width: auto !important
+    flex-shrink: 0
 
 .code--block
   display: block;

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -76,6 +76,8 @@
     width: 100% !important
     z-index: 1
     height: 100% !important
+    &:focus
+      outline: 0 !important
   .prism-editor__editor
     overflow: auto
     display: block


### PR DESCRIPTION
Adjusted styles so that the entire code preview container is the element that overflow scrolls. No need to sync.