### PR TITLE
adds instructions for using new Nuxt module in v2.5+

### DIFF
--- a/docs/guide/installation/README.md
+++ b/docs/guide/installation/README.md
@@ -52,35 +52,66 @@ Vue.use(VueFormulate.default)
 ```
 :::
 
-### Nuxt
-It's easy to use Vue Formulate on Nuxt too. [A working example is available.](https://codesandbox.io/s/vue-formulate-test-8segh?file=/components/Attending.vue)
-
-#### plugins/vue-formulate.js
-
-```js
-import Vue from 'vue'
-import VueFormulate from '@braid/vue-formulate'
-
-Vue.use(VueFormulate)
-```
-
-#### nuxt.config.js
-
-```js
-export default {
-  plugins: [
-     '~/plugins/vue-formulate',
-  ]
-  (...)
-```
-
-## Configuration options
+### Configuration options
 
 If you need custom configuration options, you can pass a second argument with
 an object of configuration options.
 
 ```js
 Vue.use(VueFormulate, options)
+```
+
+## Nuxt
+It's easy to use Vue Formulate on Nuxt too. As of version `2.5` the easiest way
+to get start with Vue Formulate on a Nuxt project is to use the included Nuxt module.
+
+For earlier versions of Vue Formulate see this [CodeSandbox implementation](https://codesandbox.io/s/vue-formulate-test-8segh?file=/nuxt.config.js)
+with a working Vue Formulate Nuxt plugin file.
+
+#### nuxt.config.js
+
+```js
+export default {
+  ...
+  buildModules: [
+    '@braid/vue-formulate/dist/nuxt'
+  ]
+  // optionally, define a path for your Vue Formulate configuration options.
+  // the default value is formulate.config.js in your Nuxt source directory
+  formulate: {
+    configPath: '~/path/to/different/formulate.config.js'
+  }
+  ...
+}
+```
+
+### Nuxt module configuration file
+
+To configure Vue Formulate with additional [plugins](/guide/plugins/),
+[locales](/guide/internationalization/), [validation rules](/guide/validation/)
+and more you can create a `formulate.config.js` file which will be imported and
+used by the Vue Formulate Nuxt module.
+
+The easiest option is to create a `formulate.config.js` file in your Nuxt project
+root and it will automatically be imported by the Nuxt module. If you wish to place
+your configuration file somewhere else, just tell the Nuxt module where it can locate
+the configuration file using the `configPath` argument of the `formulate` object in your
+`nuxt.config.js` file.
+
+Your `formulate.config.js` file should export an object which will be passed to the
+Vue Formulate registration via `Vue.use()`.
+
+#### formulate.config.js
+```js
+import { de } from '@braid/vue-formulate-i18n'
+
+export default {
+  plugins: [de],
+  locale: 'de',
+  rules: {
+    foobar: ({ value }) => ['foo', 'bar'].includes(value)
+  }
+}
 ```
 
 ## Styling/theming

--- a/docs/guide/installation/README.md
+++ b/docs/guide/installation/README.md
@@ -90,10 +90,7 @@ export default {
 To configure Vue Formulate with additional [plugins](/guide/plugins/),
 [locales](/guide/internationalization/), [validation rules](/guide/validation/)
 and more you can create a `formulate.config.js` file which will be imported and
-used by the Vue Formulate Nuxt module.
-
-The easiest option is to create a `formulate.config.js` file in your Nuxt project
-root and it will automatically be imported by the Nuxt module. If you wish to place
+used by the Vue Formulate Nuxt module.  If you wish to place
 your configuration file somewhere else, just tell the Nuxt module where it can locate
 the configuration file using the `configPath` argument of the `formulate` object in your
 `nuxt.config.js` file.

--- a/docs/guide/installation/README.md
+++ b/docs/guide/installation/README.md
@@ -74,7 +74,7 @@ with a working Vue Formulate Nuxt plugin file.
 export default {
   ...
   buildModules: [
-    '@braid/vue-formulate/dist/nuxt'
+    '@braid/vue-formulate/nuxt'
   ]
   // optionally, define a path for your Vue Formulate configuration options.
   // the default value is formulate.config.js in your Nuxt source directory


### PR DESCRIPTION
Adds the instructions for using the new [Nuxt module](https://github.com/wearebraid/vue-formulate/pull/346).