### PR TITLE
Add warning that Vue.js version 2 is required

### DIFF
--- a/docs/guide/installation/README.md
+++ b/docs/guide/installation/README.md
@@ -1,3 +1,7 @@
+::: warning
+Vue Formulate is compatible with Vue.js version 2. We're working hard on supporting Vue.js version 3
+:::
+
 # Installation
 The preferred way to use Vue Formulate is to install via your favorite JavaScript
 package manager.


### PR DESCRIPTION
I read through the documentation, thought "Wow! Vue Formulate looks amazing!" and installed it - only to find it's not compatible with Vue.js version 3 (yet).

To save other people having the same experience, I propose adding a warning to the documentation.