### PR TITLE
docs: fix changelog yaml preabmle

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -1,5 +1,3 @@
-
-
 ---
 sidebar: auto
 ---


### PR DESCRIPTION
This PR makes the yaml preamble of the changelog move up to the top of the file, so it is treated as a yaml preamble and not some sort of heading.