### PR TITLE
Update README.md

### DIFF
--- a/docs/guide/installation/README.md
+++ b/docs/guide/installation/README.md
@@ -56,6 +56,17 @@ Vue.use(VueFormulate.default)
 ```
 :::
 
+## Using a Progressive Web App without the CLI
+If you are integrating vue into a legecy project or app where vue is not 
+the primary framework you'll need to import Formulate in your components.
+
+```js
+....
+<script>
+  import { FormulateInput } from '@braid/vue-formulate/dist/formulate.min.js';
+....
+```
+
 ### Configuration options
 
 If you need custom configuration options, you can pass a second argument with


### PR DESCRIPTION
Added import instructions for the 'do it yourself'ers' who weren't lucky enough to start their apps in Vue.  If importing in modules is still necessary for SPA's and that step is still missing from the docs, someone else will need to confirm.